### PR TITLE
Updated zmq_decoder.py and dropped cpu drastically

### DIFF
--- a/zmq_decoder.py
+++ b/zmq_decoder.py
@@ -1,22 +1,25 @@
-#!/usr/bin/env python3                                                                                                    
+#!/usr/bin/env python3
+# (c) 2024 B.Kerler
 import json
 import sys
 import time
-from io import BytesIO
-
 import zmq
 import argparse
+import serial
 from threading import Thread
 from OpenDroneID.decoder import decode_ble, decode
 from OpenDroneID.utils import structhelper_io
 
+verbose = False  # Global variable to control verbosity
+stop = False
+
 
 def log(*msg):
-    s = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-    print(f"{s}:", *msg, end="\n", file=sys.stderr)
-
-
-stop = False
+    """Logs messages to stderr if verbose is enabled."""
+    global verbose
+    if verbose:
+        s = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        print(f"{s}:", *msg, end="\n", file=sys.stderr)
 
 
 def zmq_thread(pub_socket):
@@ -25,11 +28,11 @@ def zmq_thread(pub_socket):
         while not stop:
             try:
                 event = pub_socket.recv()
-                # Event is one byte 0=unsub or 1=sub, followed by topic
-                if event[0] == 1:
-                    log("new subscriber for", event[1:])
-                elif event[0] == 0:
-                    log("unsubscribed", event[1:])
+                if verbose:
+                    if event[0] == 1:
+                        log("New subscriber for", event[1:])
+                    elif event[0] == 0:
+                        log("Unsubscribed", event[1:])
             except zmq.error.ContextTerminated:
                 break
             except Exception as e:
@@ -38,13 +41,13 @@ def zmq_thread(pub_socket):
         pass
 
 
-def decoder_thread(socket, pub, verbose):
+def decoder_thread(socket, pub):
     global stop
     poller = zmq.Poller()
     poller.register(socket, zmq.POLLIN)
     try:
         while not stop:
-            socks = dict(poller.poll(1000))  # Poll with 1000ms timeout
+            socks = dict(poller.poll(3000))  # Poll every 3 seconds
             if socket in socks and socks[socket] == zmq.POLLIN:
                 try:
                     data = socket.recv()
@@ -61,66 +64,9 @@ def decoder_thread(socket, pub, verbose):
                             log("JSON Decode Error:", e)
                         continue
 
-                    if "AUX_ADV_IND" in dc and "aa" in dc["AUX_ADV_IND"] and dc["AUX_ADV_IND"]["aa"] == 0x8e89bed6:
-                        if "AdvData" in dc:
-                            try:
-                                advdata = bytearray(bytes.fromhex(dc["AdvData"]))
-                            except ValueError as e:
-                                if verbose:
-                                    log("AdvData Decode Error:", e)
-                                continue
-
-                            if advdata[1] == 0x16 and int.from_bytes(advdata[2:4], 'little') == 0xFFFA and advdata[4] == 0x0D:
-                                # Open Drone ID
-                                if verbose:
-                                    print("Open Drone ID BT4/BT5\n-------------------------\n")
-                                try:
-                                    json_data = decode_ble(advdata)
-                                except Exception as e:
-                                    if verbose:
-                                        log("decode_ble Error:", e)
-                                    continue
-
-                                if pub:
-                                    pub.send_string(json_data)
-                                if verbose:
-                                    print(json_data)
-                                    print()
-                                sys.stdout.flush()
-                    elif "DroneID" in dc:
-                        for mac, field in dc["DroneID"].items():
-                            # Open Drone ID
-                            if verbose:
-                                print("Open Drone ID WIFI\n-------------------------\n")
-                            if "AdvData" in field:
-                                try:
-                                    fields = decode(structhelper_io(bytes.fromhex(field["AdvData"])))
-                                    for field_decoded in fields:
-                                        field_decoded["MAC"] = mac
-                                        json_data = json.dumps(field_decoded).decode('utf-8')
-                                        if pub:
-                                            pub.send_string(json_data)
-                                        if verbose:
-                                            print(json_data)
-                                except Exception as e:
-                                    if verbose:
-                                        log("Decoding Error:", e)
-                                    pass
-                            else:
-                                try:
-                                    field["MAC"] = mac
-                                    json_data = json.dumps(field).decode('utf-8')
-                                    if pub:
-                                        pub.send_string(json_data)
-                                    if verbose:
-                                        print(json_data)
-                                except Exception as e:
-                                    if verbose:
-                                        log("JSON Dump Error:", e)
-                                    pass
-                            if verbose:
-                                print()
-                            sys.stdout.flush()
+                    if verbose:
+                        print("ZMQ Data Received:", json.dumps(dc, indent=2))
+                    process_decoded_data(dc, pub)
     except zmq.error.ContextTerminated:
         pass
     except Exception as e:
@@ -128,15 +74,103 @@ def decoder_thread(socket, pub, verbose):
             log("Decoder Thread Error:", e)
 
 
+def uart_listener(uart_device, pub):
+    global stop
+    buffer = ""
+    with serial.Serial(uart_device, baudrate=115200, timeout=1) as ser:
+        while not stop:
+            if ser.in_waiting > 0:
+                try:
+                    data = ser.read(ser.in_waiting).decode('utf-8')
+                    buffer += data
+                    # Process only when a complete JSON message is detected
+                    if buffer.count("{") == buffer.count("}"):
+                        if verbose:
+                            print("UART received:", buffer)
+
+                        try:
+                            dc = json.loads(buffer)
+                            json_data = json.dumps(dc)
+                            if pub:
+                                pub.send_string(json_data)
+                            if verbose:
+                                print(f"Forwarded via ZMQ: {json_data}")
+                            buffer = ""
+                        except json.JSONDecodeError as e:
+                            if verbose:
+                                log("UART JSON Decode Error:", e)
+                            buffer = ""
+                except Exception as e:
+                    if verbose:
+                        log("UART Read Error:", e)
+            else:
+                time.sleep(0.1)
+
+
+def process_decoded_data(dc, pub):
+    """Processes and forwards the decoded data via ZMQ."""
+    if "AUX_ADV_IND" in dc and "aa" in dc["AUX_ADV_IND"] and dc["AUX_ADV_IND"]["aa"] == 0x8e89bed6:
+        if "AdvData" in dc:
+            try:
+                advdata = bytearray(bytes.fromhex(dc["AdvData"]))
+                if advdata[1] == 0x16 and int.from_bytes(advdata[2:4], 'little') == 0xFFFA and advdata[4] == 0x0D:
+                    if verbose:
+                        print("Open Drone ID BT4/BT5\n-------------------------\n")
+                    json_data = decode_ble(advdata)
+                    if pub:
+                        pub.send_string(json_data)
+                    if verbose:
+                        print(json_data)
+                        print()
+                    sys.stdout.flush()
+            except ValueError as e:
+                if verbose:
+                    log("AdvData Decode Error:", e)
+
+    elif "DroneID" in dc:
+        for mac, field in dc["DroneID"].items():
+            if verbose:
+                print("Open Drone ID WIFI\n-------------------------\n")
+            if "AdvData" in field:
+                try:
+                    fields = decode(structhelper_io(bytes.fromhex(field["AdvData"])))
+                    for field_decoded in fields:
+                        field_decoded["MAC"] = mac
+                        json_data = json.dumps(field_decoded)
+                        if pub:
+                            pub.send_string(json_data)
+                        if verbose:
+                            print(json_data)
+                except Exception as e:
+                    if verbose:
+                        log("Decoding Error:", e)
+            else:
+                try:
+                    field["MAC"] = mac
+                    json_data = json.dumps(field)
+                    if pub:
+                        pub.send_string(json_data)
+                    if verbose:
+                        print(json_data)
+                except Exception as e:
+                    if verbose:
+                        log("JSON Dump Error:", e)
+            if verbose:
+                print()
+            sys.stdout.flush()
+
+
 def main():
     global stop
+    global verbose
     verbose = False
     info = "ZMQ decoder for BLE4/5 + WIFI ZMQ clients (c) B.Kerler 2024"
     aparse = argparse.ArgumentParser(description=info)
-    aparse.add_argument("-z", "--zmq", action="store_true", help="Enable zmq")
+    aparse.add_argument("-z", "--zmq", action="store_true", help="Enable ZMQ")
     aparse.add_argument("-v", "--verbose", action="store_true", help="Print decoded messages")
-    aparse.add_argument("--zmqsetting", default="127.0.0.1:4224", help="Define zmq server settings")
-    aparse.add_argument("--zmqclients", default="127.0.0.1:4222,127.0.0.1:4223", help="Define bluetooth/wifi zmq clients")
+    aparse.add_argument("--zmqsetting", default="127.0.0.1:4224", help="Define ZMQ server settings")
+    aparse.add_argument("--zmqclients", default="127.0.0.1:4222,127.0.0.1:4223", help="Define Bluetooth/Wi-Fi ZMQ clients")
+    aparse.add_argument("--uart", help="UART device for pre-decoded ESP32 data (e.g., /dev/ttyACM0)")
     args = aparse.parse_args()
 
     verbose = args.verbose
@@ -146,7 +180,7 @@ def main():
 
     if args.zmq:
         pub = sctx.socket(zmq.XPUB)
-        sctx.setsockopt(zmq.XPUB_VERBOSE, True)
+        pub.setsockopt(zmq.XPUB_VERBOSE, True)
         purl = f"tcp://{args.zmqsetting}"
         pub.bind(purl)
 
@@ -156,21 +190,26 @@ def main():
         pub = None
         zthread = None
 
+    # Set up UART and ZMQ client listeners concurrently
+    if args.uart:
+        uart_thread = Thread(target=uart_listener, args=(args.uart, pub), daemon=True)
+        uart_thread.start()
+
     clients = args.zmqclients.split(",")
     subs = []
     for client in clients:
         url = f"tcp://{client}"
         sub = sctx.socket(zmq.SUB)
-        # Subscribe to both topics
         sub.setsockopt(zmq.SUBSCRIBE, b'{"AUX_ADV_IND"')
         sub.setsockopt(zmq.SUBSCRIBE, b'{"DroneID"')
         try:
             sub.connect(url)
         except zmq.error.ZMQError as e:
-            log(f"Failed to connect to {url}: {e}")
+            if verbose:
+                log(f"Failed to connect to {url}: {e}")
             continue
 
-        dthread = Thread(target=decoder_thread, args=(sub, pub, verbose), daemon=True, name=f'decoder-{client}')
+        dthread = Thread(target=decoder_thread, args=(sub, pub), daemon=True, name=f'decoder-{client}')
         dthread.start()
         subs.append(dthread)
 
@@ -178,25 +217,21 @@ def main():
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
-        log("Interrupt received, shutting down...")
+        if verbose:
+            log("Interrupt received, shutting down...")
     finally:
         stop = True
-        # Close all sockets
-        for client in clients:
-            try:
-                sub.close()
-            except:
-                pass
         if pub:
             pub.close()
-        # Terminate context
         sctx.term()
-        # Wait for threads to finish
+        if args.uart:
+            uart_thread.join()
         for thread in subs:
             thread.join()
         if zthread:
             zthread.join()
-        log("Shutdown complete.")
+        if verbose:
+            log("Shutdown complete.")
 
 
 if __name__ == "__main__":

--- a/zmq_decoder.py
+++ b/zmq_decoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3                                                                                                    
 import json
 import sys
 import time
@@ -13,86 +13,120 @@ from OpenDroneID.utils import structhelper_io
 
 def log(*msg):
     s = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-    print("%s:" % s, *msg, end="\n", file=sys.stderr)
+    print(f"{s}:", *msg, end="\n", file=sys.stderr)
+
 
 stop = False
 
-def zmq_thread(socket):
+
+def zmq_thread(pub_socket):
     global stop
     try:
         while not stop:
-            event = socket.recv()
-            # Event is one byte 0=unsub or 1=sub, followed by topic
-            if event[0] == 1:
-                log("new subscriber for", event[1:])
-            elif event[0] == 0:
-                log("unsubscribed", event[1:])
+            try:
+                event = pub_socket.recv()
+                # Event is one byte 0=unsub or 1=sub, followed by topic
+                if event[0] == 1:
+                    log("new subscriber for", event[1:])
+                elif event[0] == 0:
+                    log("unsubscribed", event[1:])
+            except zmq.error.ContextTerminated:
+                break
+            except Exception as e:
+                log("ZMQ Thread Error:", e)
     except zmq.error.ContextTerminated:
         pass
 
 
 def decoder_thread(socket, pub, verbose):
     global stop
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
     try:
         while not stop:
-            try:
-                data = socket.recv(zmq.NOBLOCK)
-            except:
-                data = None
-            if data is not None:
-                dc = json.loads(data.decode('utf-8'))
-                if "AUX_ADV_IND" in dc and "aa" in dc["AUX_ADV_IND"] and dc["AUX_ADV_IND"]["aa"] == 0x8e89bed6:
-                    if "AdvData" in dc:
-                        advdata = bytearray(bytes.fromhex(dc["AdvData"]))
-                        if advdata[1] == 0x16 and int.from_bytes(advdata[2:4], 'little') == 0xFFFA and advdata[
-                            4] == 0x0D:
-                            # Open Drone ID
-                            if verbose:
-                                print("Open Drone ID BT4/BT5\n-------------------------\n")
-                            json_data = decode_ble(advdata)
-                            if pub:
-                                pub.send_string(json_data)
-                            if verbose:
-                                print(json_data)
-                                print()
-                            sys.stdout.flush()
-                elif "DroneID" in dc:
-                    for mac in dc["DroneID"]:
-                        # Open Drone ID
-                        field = dc["DroneID"][mac]
+            socks = dict(poller.poll(1000))  # Poll with 1000ms timeout
+            if socket in socks and socks[socket] == zmq.POLLIN:
+                try:
+                    data = socket.recv()
+                except zmq.error.ZMQError as e:
+                    if verbose:
+                        log("Receive Error:", e)
+                    continue
+
+                if data:
+                    try:
+                        dc = json.loads(data.decode('utf-8'))
+                    except json.JSONDecodeError as e:
                         if verbose:
-                            print("Open Drone ID WIFI\n-------------------------\n")
-                        if "AdvData" in field:
+                            log("JSON Decode Error:", e)
+                        continue
+
+                    if "AUX_ADV_IND" in dc and "aa" in dc["AUX_ADV_IND"] and dc["AUX_ADV_IND"]["aa"] == 0x8e89bed6:
+                        if "AdvData" in dc:
                             try:
-                                fields = decode(structhelper_io(bytes.fromhex(field["AdvData"])))
-                                for field in fields:
-                                    field["MAC"]=mac
-                                    json_data = json.dumps(field)
-                                    if pub:
-                                        pub.send_string(json_data)
-                                    if verbose:
-                                        print(json_data)
-                            except Exception as e:
+                                advdata = bytearray(bytes.fromhex(dc["AdvData"]))
+                            except ValueError as e:
                                 if verbose:
-                                    print(e)
-                                pass
-                        else:
-                            try:
-                                field["MAC"]=mac
-                                json_data = json.dumps(field)
+                                    log("AdvData Decode Error:", e)
+                                continue
+
+                            if advdata[1] == 0x16 and int.from_bytes(advdata[2:4], 'little') == 0xFFFA and advdata[4] == 0x0D:
+                                # Open Drone ID
+                                if verbose:
+                                    print("Open Drone ID BT4/BT5\n-------------------------\n")
+                                try:
+                                    json_data = decode_ble(advdata)
+                                except Exception as e:
+                                    if verbose:
+                                        log("decode_ble Error:", e)
+                                    continue
+
                                 if pub:
                                     pub.send_string(json_data)
                                 if verbose:
                                     print(json_data)
-                            except Exception as e:
-                                if verbose:
-                                    print(e)
-                                pass
-                        if verbose:
-                            print()
-                        sys.stdout.flush()
+                                    print()
+                                sys.stdout.flush()
+                    elif "DroneID" in dc:
+                        for mac, field in dc["DroneID"].items():
+                            # Open Drone ID
+                            if verbose:
+                                print("Open Drone ID WIFI\n-------------------------\n")
+                            if "AdvData" in field:
+                                try:
+                                    fields = decode(structhelper_io(bytes.fromhex(field["AdvData"])))
+                                    for field_decoded in fields:
+                                        field_decoded["MAC"] = mac
+                                        json_data = json.dumps(field_decoded).decode('utf-8')
+                                        if pub:
+                                            pub.send_string(json_data)
+                                        if verbose:
+                                            print(json_data)
+                                except Exception as e:
+                                    if verbose:
+                                        log("Decoding Error:", e)
+                                    pass
+                            else:
+                                try:
+                                    field["MAC"] = mac
+                                    json_data = json.dumps(field).decode('utf-8')
+                                    if pub:
+                                        pub.send_string(json_data)
+                                    if verbose:
+                                        print(json_data)
+                                except Exception as e:
+                                    if verbose:
+                                        log("JSON Dump Error:", e)
+                                    pass
+                            if verbose:
+                                print()
+                            sys.stdout.flush()
     except zmq.error.ContextTerminated:
         pass
+    except Exception as e:
+        if verbose:
+            log("Decoder Thread Error:", e)
+
 
 def main():
     global stop
@@ -105,40 +139,65 @@ def main():
     aparse.add_argument("--zmqclients", default="127.0.0.1:4222,127.0.0.1:4223", help="Define bluetooth/wifi zmq clients")
     args = aparse.parse_args()
 
+    verbose = args.verbose
+
+    # Initialize a single ZMQ context
+    sctx = zmq.Context()
+
     if args.zmq:
-        sctx = zmq.Context()
         pub = sctx.socket(zmq.XPUB)
         sctx.setsockopt(zmq.XPUB_VERBOSE, True)
         purl = f"tcp://{args.zmqsetting}"
         pub.bind(purl)
 
-        zthread = Thread(target=zmq_thread, args=[pub], daemon=True, name='zmq')
+        zthread = Thread(target=zmq_thread, args=(pub,), daemon=True, name='zmq')
         zthread.start()
     else:
         pub = None
+        zthread = None
 
     clients = args.zmqclients.split(",")
     subs = []
     for client in clients:
-        url=f"tcp://{client}"
-        ctx = zmq.Context()
-        sub = ctx.socket(zmq.SUB)
-        sub.setsockopt(zmq.SUBSCRIBE, bytes('{"AUX_ADV_IND"', 'utf-8'))
-        sub.setsockopt(zmq.SUBSCRIBE, bytes('{"DroneID"', 'utf-8'))
-        if sub.connect(url):
-            zthread = Thread(target=decoder_thread, args=[sub,pub,verbose], daemon=True, name='zmq')
-            zthread.start()
-            subs.append(zthread)
-
-    while True:
+        url = f"tcp://{client}"
+        sub = sctx.socket(zmq.SUB)
+        # Subscribe to both topics
+        sub.setsockopt(zmq.SUBSCRIBE, b'{"AUX_ADV_IND"')
+        sub.setsockopt(zmq.SUBSCRIBE, b'{"DroneID"')
         try:
+            sub.connect(url)
+        except zmq.error.ZMQError as e:
+            log(f"Failed to connect to {url}: {e}")
+            continue
+
+        dthread = Thread(target=decoder_thread, args=(sub, pub, verbose), daemon=True, name=f'decoder-{client}')
+        dthread.start()
+        subs.append(dthread)
+
+    try:
+        while True:
             time.sleep(1)
-        except KeyboardInterrupt:
-            break
-    stop = True
-    for thread in subs:
-        thread.join()
-    zthread.join()
+    except KeyboardInterrupt:
+        log("Interrupt received, shutting down...")
+    finally:
+        stop = True
+        # Close all sockets
+        for client in clients:
+            try:
+                sub.close()
+            except:
+                pass
+        if pub:
+            pub.close()
+        # Terminate context
+        sctx.term()
+        # Wait for threads to finish
+        for thread in subs:
+            thread.join()
+        if zthread:
+            zthread.join()
+        log("Shutdown complete.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I improved how the program handles ZeroMQ (ZMQ) sockets and the main loop to reduce CPU usage. Instead of constantly checking for new data, the program now waits for messages more efficiently. This change makes the application run smoother and use less computer power. Additionally, I made sure that all sockets are managed properly, which helps the program shut down cleanly without any issues.

Prior to the changes if I had just one zmqclient specified I would hit 100% cpu on one core as it was decoding BT. With both clients specified but still only doing BT - the cpu usage was still high but spread across cores. 

Check what I'm saying and see if you find the same. 